### PR TITLE
Scope scalatest to test, not global, dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-hyperloglog"
 
-version := "1.0.2"
+version := "1.0.3"
 
 scalaVersion := "2.10.6"
 
@@ -11,7 +11,7 @@ sparkVersion := "1.6.0"
 sparkComponents ++= Seq("core", "sql")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.1",
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "com.twitter" %% "algebird-core" % "0.12.0"
 )
 


### PR DESCRIPTION
For context, see Bug 1298123:  Refactor dataset classes so they do not use case classes

Upgrading the telemetry-batch-view library to 2.11 creates a scalatest dependency conflict with this package. Limiting the scalatest dependency to testing will remove the current and prevent future conflicts.
